### PR TITLE
Fix bin file exists check

### DIFF
--- a/PS5 NOR Modifier/Form1.cs
+++ b/PS5 NOR Modifier/Form1.cs
@@ -365,7 +365,7 @@ namespace PS5_NOR_Modifier
 
             if (fileDialogBox.ShowDialog() == DialogResult.OK)
             {
-                if(fileDialogBox.CheckFileExists == false)
+                if (!File.Exists(fileDialogBox.FileName))
                 {
                     throwError("The file you selected could not be found. Please check the file exists and is a valid BIN file.");
                 }


### PR DESCRIPTION
The previous code was using a configuration property to check if the file exists, which would always pass because it defaults to `true`.