### PR TITLE
feat: Add PR+issue templates/forms (#42)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,41 @@
+name: Bug Report
+description: File a bug report.
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: "## Bug Report"
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: What version are you using?
+    validations:
+      required: true
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      options:
+        - PS5 NOR Modifier
+        - UART-CL
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this issue?
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+  - type: input
+    id: logs
+    attributes:
+      label: Relevant Logs/Screenshots

--- a/.github/ISSUE_TEMPLATE/documentation_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_improvement.yml
@@ -1,0 +1,25 @@
+name: Documentation Improvement Request
+description: Request documentation improvements
+title: "[Documentation]: "
+labels: ["Documentation", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: "## Documentation Improvement"
+  - type: input
+    id: doc_link
+    attributes:
+      label: Documentation Link
+      description: Which documentation needs improvement?
+    validations:
+      required: true
+  - type: textarea
+    id: missing_info
+    attributes:
+      label: Missing/Incorrect Information
+    validations:
+      required: true
+  - type: textarea
+    id: suggested_changes
+    attributes:
+      label: Suggested Changes

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,33 @@
+name: Feature Request
+description: Request a feature.
+title: "[Feature]: "
+labels: ["feature", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: "## Feature Request"
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem are you trying to solve?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Additional Checks
+      options:
+        - label: I've searched existing issues to avoid duplicates
+          required: true
+        - label: I'm willing to contribute to this feature

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+# Pull Request
+
+## Description
+<!-- Provide a clear description of the changes made in this PR -->
+
+## Related Issue(s)
+<!-- Link to the related issues using the GitHub syntax (e.g., "Fixes #123", "Resolves #456") -->
+
+## Type of Change
+<!-- Mark the appropriate option with an "x" (fill in the [ ] with an x, no spaces) -->
+
+- [ ] Bug Fix (non-breaking change that fixes an issue)
+- [ ] New Feature (non-breaking change that adds functionality)
+- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
+- [ ] CI/CD Improvement (changes to build, deploy, or workflow processes)
+- [ ] Other (please describe):
+
+## Checklist
+<!-- Mark items with an "x" as completed (fill in the [ ] with an x, no spaces) -->
+
+- [ ] I have performed a review of my own code
+- [ ] I have commented my code, especially in hard-to-understand areas
+- [ ] I have added tests or prove my fix is effective or that my feature works
+- [ ] I have checked my code and corrected any misspellings
+
+## Screenshots
+<!-- If applicable, add screenshots to help explain your changes if needed -->
+
+## Additional Notes
+<!-- Add any other context about the PR here -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,3 @@
-# Pull Request
-
 ## Description
 <!-- Provide a clear description of the changes made in this PR -->
 


### PR DESCRIPTION
# Pull Request

## Description
Add standardized templates for GitHub contributions using YAML-based issue forms, PR templates, and other contribution workflows.

## Related Issue(s)
closes #42 

## Type of Change
<!-- Mark the appropriate option with an "x" (fill in the [ ] with an x, no spaces) -->

- [ ] Bug Fix (non-breaking change that fixes an issue)
- [ ] New Feature (non-breaking change that adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] CI/CD Improvement (changes to build, deploy, or workflow processes)
- [x] Other (please describe):

## Checklist
<!-- Mark items with an "x" as completed (fill in the [ ] with an x, no spaces) -->

- [x] I have performed a review of my own code
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added tests or prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings

## Screenshots
![Screenshot 2025-05-17 at 16 47 07](https://github.com/user-attachments/assets/a17dbfd7-7afe-420c-bc9b-201e1b9140c7)


## Additional Notes
Tested in another repository. See screenshot.